### PR TITLE
Changes to Menu Item Spacing

### DIFF
--- a/Ice/MenuBarItemSpacing/MenuBarItemSpacingManager.swift
+++ b/Ice/MenuBarItemSpacing/MenuBarItemSpacingManager.swift
@@ -28,7 +28,7 @@ class MenuBarItemSpacingManager {
         let failedApps: [String]
 
         var errorDescription: String? {
-            "The following applications failed to relaunch:\n" + failedApps.joined(separator: "\n")
+            "The following applications failed to quit and were not restarted:\n" + failedApps.joined(separator: "\n")
         }
 
         var recoverySuggestion: String? {
@@ -39,6 +39,9 @@ class MenuBarItemSpacingManager {
     /// The offset to apply to the default spacing and padding.
     /// Does not take effect until ``applyOffset()`` is called.
     var offset = 0
+
+    /// The wait time before force terminating an app.
+    private let waitTimeBeforeForceTerminate: UInt64 = 3_000_000_000 // 3 seconds in nanoseconds
 
     /// Runs a command with the given arguments.
     private func runCommand(_ command: String, with arguments: [String]) async throws {
@@ -65,14 +68,25 @@ class MenuBarItemSpacingManager {
         try await runCommand("defaults", with: ["-currentHost", "write", "-globalDomain", key.rawValue, "-int", String(key.defaultValue + offset)])
     }
 
-    /// Asynchronously quits the given app.
-    private func quitApp(_ app: NSRunningApplication) async throws {
-        try await runCommand("kill", with: [String(app.processIdentifier)])
+    /// Asynchronously signals the given app to quit.
+    private func signalAppToQuit(_ app: NSRunningApplication) async throws {
+        Logger.spacing.debug("Signaling application \"\(app.localizedName ?? "<NIL>")\" to quit")
+        app.terminate()
         var cancellable: AnyCancellable?
         return try await withCheckedThrowingContinuation { continuation in
+            let timeoutTask = Task {
+                try await Task.sleep(nanoseconds: self.waitTimeBeforeForceTerminate)
+                if !app.isTerminated {
+                    Logger.spacing.debug("Application \"\(app.localizedName ?? "<NIL>")\" did not terminate within \(self.waitTimeBeforeForceTerminate / 1_000_000_000) seconds, attempting to force terminate")
+                    app.forceTerminate()
+                }
+            }
+
             cancellable = app.publisher(for: \.isTerminated).sink { isTerminated in
                 if isTerminated {
+                    timeoutTask.cancel()
                     cancellable?.cancel()
+                    Logger.spacing.debug("Application \"\(app.localizedName ?? "<NIL>")\" terminated successfully")
                     continuation.resume()
                 }
             }
@@ -95,16 +109,20 @@ class MenuBarItemSpacingManager {
 
     /// Asynchronously relaunches the given app.
     private func relaunchApp(_ app: NSRunningApplication) async throws {
-        struct RelaunchError: Error { }
+        struct RelaunchError: Error {}
         guard
             let url = app.bundleURL,
             let bundleIdentifier = app.bundleIdentifier
         else {
             throw RelaunchError()
         }
-        try await quitApp(app)
-        try? await Task.sleep(for: .milliseconds(50))
-        try await launchApp(at: url, bundleIdentifier: bundleIdentifier)
+        try await signalAppToQuit(app)
+        try? await Task.sleep(for: .nanoseconds(waitTimeBeforeForceTerminate))
+        if app.isTerminated {
+            try await launchApp(at: url, bundleIdentifier: bundleIdentifier)
+        } else {
+            throw RelaunchError()
+        }
     }
 
     /// Applies the current ``offset``.
@@ -125,30 +143,44 @@ class MenuBarItemSpacingManager {
         let pids = Set(items.map { $0.ownerPID })
 
         var failedApps = [String]()
+        var tasks = [Task<Void, Never>]()
 
         for pid in pids {
             guard
                 let app = NSRunningApplication(processIdentifier: pid),
-                // ControlCenter handles its own relaunch, so quit it separately
+                // ControlCenter handles its own relaunch, so skip it
                 app.bundleIdentifier != "com.apple.controlcenter",
                 app != .current
             else {
                 continue
             }
-            do {
-                try await relaunchApp(app)
-            } catch {
-                if let name = app.localizedName {
-                    failedApps.append(name)
+            tasks.append(Task {
+                do {
+                    try await self.relaunchApp(app)
+                } catch {
+                    if let name = app.localizedName {
+                        failedApps.append(name)
+                    }
                 }
-            }
+            })
+        }
+
+        // Wait for all tasks to complete
+        for task in tasks {
+            await task.value
         }
 
         try? await Task.sleep(for: .milliseconds(100))
 
         if let app = NSRunningApplication.runningApplications(withBundleIdentifier: "com.apple.controlcenter").first {
             do {
-                try await quitApp(app)
+                try await signalAppToQuit(app)
+                try? await Task.sleep(for: .nanoseconds(waitTimeBeforeForceTerminate))
+                if !app.isTerminated {
+                    if let name = app.localizedName {
+                        failedApps.append(name)
+                    }
+                }
             } catch {
                 if let name = app.localizedName {
                     failedApps.append(name)

--- a/Ice/MenuBarItemSpacing/MenuBarItemSpacingManager.swift
+++ b/Ice/MenuBarItemSpacing/MenuBarItemSpacingManager.swift
@@ -8,6 +8,7 @@ import Combine
 import OSLog
 
 /// Manager for menu bar item spacing.
+@MainActor
 class MenuBarItemSpacingManager {
     /// UserDefaults keys.
     private enum Key: String {
@@ -94,7 +95,7 @@ class MenuBarItemSpacingManager {
     }
 
     /// Asynchronously launches the app at the given URL.
-    private func launchApp(at applicationURL: URL, bundleIdentifier: String) async throws {
+    private nonisolated func launchApp(at applicationURL: URL, bundleIdentifier: String) async throws {
         if let app = NSWorkspace.shared.runningApplications.first(where: { $0.bundleIdentifier == bundleIdentifier }) {
             Logger.spacing.debug("Application \"\(app.localizedName ?? "<NIL>")\" is already open, so skipping launch")
             return
@@ -109,7 +110,7 @@ class MenuBarItemSpacingManager {
 
     /// Asynchronously relaunches the given app.
     private func relaunchApp(_ app: NSRunningApplication) async throws {
-        struct RelaunchError: Error {}
+        struct RelaunchError: Error { }
         guard
             let url = app.bundleURL,
             let bundleIdentifier = app.bundleIdentifier

--- a/Ice/MenuBarSearch/MenuBarSearchPanel.swift
+++ b/Ice/MenuBarSearch/MenuBarSearchPanel.swift
@@ -61,7 +61,11 @@ class MenuBarSearchPanel: NSPanel {
             return
         }
 
-        // important that we set the navigation before updating the cache
+        // Set the desired frame size for the panel before positioning
+        let panelSize = CGSize(width: 600, height: 400)
+        setFrame(NSRect(origin: .zero, size: panelSize), display: false)
+
+        // Important that we set the navigation before updating the cache
         appState.navigationState.isSearchPresented = true
 
         await appState.imageCache.updateCache()
@@ -97,6 +101,7 @@ class MenuBarSearchPanel: NSPanel {
         mouseDownMonitor?.start()
         keyDownMonitor?.start()
 
+        // Calculate the top-left position
         let topLeft = CGPoint(
             x: screen.frame.midX - frame.width / 2,
             y: screen.frame.midY + (frame.height / 2) + (screen.frame.height / 8)

--- a/Ice/Settings/SettingsManagers/AdvancedSettingsManager.swift
+++ b/Ice/Settings/SettingsManagers/AdvancedSettingsManager.swift
@@ -6,6 +6,7 @@
 import Combine
 import Foundation
 
+@MainActor
 final class AdvancedSettingsManager: ObservableObject {
     /// Valid modifier keys that can be used to trigger the secondary
     /// action of all control items.

--- a/Ice/Settings/SettingsManagers/GeneralSettingsManager.swift
+++ b/Ice/Settings/SettingsManagers/GeneralSettingsManager.swift
@@ -7,6 +7,7 @@ import Combine
 import Foundation
 import OSLog
 
+@MainActor
 final class GeneralSettingsManager: ObservableObject {
     /// A Boolean value that indicates whether the Ice icon
     /// should be shown.

--- a/Ice/Settings/SettingsManagers/HotkeySettingsManager.swift
+++ b/Ice/Settings/SettingsManagers/HotkeySettingsManager.swift
@@ -6,6 +6,7 @@
 import Combine
 import OSLog
 
+@MainActor
 final class HotkeySettingsManager: ObservableObject {
     @Published private(set) var hotkeys = HotkeyAction.allCases.map { action in
         Hotkey(keyCombination: nil, action: action)

--- a/Ice/Settings/SettingsManagers/SettingsManager.swift
+++ b/Ice/Settings/SettingsManagers/SettingsManager.swift
@@ -5,6 +5,7 @@
 
 import Combine
 
+@MainActor
 final class SettingsManager: ObservableObject {
     let generalSettingsManager: GeneralSettingsManager
 

--- a/Ice/Settings/SettingsWindow.swift
+++ b/Ice/Settings/SettingsWindow.swift
@@ -16,9 +16,28 @@ struct SettingsWindow: Scene {
                 .onAppear(perform: onAppear)
                 .environmentObject(appState)
                 .environmentObject(appState.navigationState)
+                .background(WindowAccessor { window in
+                    window.level = .floating
+                })
         }
         .commandsRemoved()
         .windowResizability(.contentSize)
         .defaultSize(width: 900, height: 625)
     }
+}
+
+struct WindowAccessor: NSViewRepresentable {
+    var onReceiveWindow: (NSWindow) -> Void
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async {
+            if let window = view.window {
+                self.onReceiveWindow(window)
+            }
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
 }

--- a/Ice/Settings/SettingsWindow.swift
+++ b/Ice/Settings/SettingsWindow.swift
@@ -16,28 +16,12 @@ struct SettingsWindow: Scene {
                 .onAppear(perform: onAppear)
                 .environmentObject(appState)
                 .environmentObject(appState.navigationState)
-                .background(WindowAccessor { window in
-                    window.level = .floating
-                })
+                .readWindow { window in
+                    window?.level = .floating
+                }
         }
         .commandsRemoved()
         .windowResizability(.contentSize)
         .defaultSize(width: 900, height: 625)
     }
-}
-
-struct WindowAccessor: NSViewRepresentable {
-    var onReceiveWindow: (NSWindow) -> Void
-
-    func makeNSView(context: Context) -> NSView {
-        let view = NSView()
-        DispatchQueue.main.async {
-            if let window = view.window {
-                self.onReceiveWindow(window)
-            }
-        }
-        return view
-    }
-
-    func updateNSView(_ nsView: NSView, context: Context) {}
 }


### PR DESCRIPTION
- Instead of killing apps we terminate() them gracefully. Only if they do not terminate within 3 second, we forceTerminate() them.
- Disable buttons while restarting apps
- Draw progress circle
- Make Ice settings window always stay on top