### PR TITLE
Add config option for right click on menubar

### DIFF
--- a/Ice/Events/EventManager.swift
+++ b/Ice/Events/EventManager.swift
@@ -256,6 +256,7 @@ extension EventManager {
     private func handleShowRightClickMenu() {
         guard
             let appState,
+            appState.settingsManager.advancedSettingsManager.showContextMenuOnRightClick,
             isMouseInsideEmptyMenuBarSpace,
             let mouseLocation = MouseCursor.locationAppKit
         else {

--- a/Ice/Settings/SettingsManagers/AdvancedSettingsManager.swift
+++ b/Ice/Settings/SettingsManagers/AdvancedSettingsManager.swift
@@ -34,6 +34,8 @@ final class AdvancedSettingsManager: ObservableObject {
     /// the user is dragging items in the menu bar.
     @Published var showAllSectionsOnUserDrag = true
 
+    @Published var showContextMenuOnRightClick = true
+
     /// Storage for internal observers.
     private var cancellables = Set<AnyCancellable>()
 
@@ -57,6 +59,7 @@ final class AdvancedSettingsManager: ObservableObject {
         Defaults.ifPresent(key: .showOnHoverDelay, assign: &showOnHoverDelay)
         Defaults.ifPresent(key: .tempShowInterval, assign: &tempShowInterval)
         Defaults.ifPresent(key: .showAllSectionsOnUserDrag, assign: &showAllSectionsOnUserDrag)
+        Defaults.ifPresent(key: .showContextMenuOnRightClick, assign: &showContextMenuOnRightClick)
     }
 
     private func configureCancellables() {
@@ -108,6 +111,13 @@ final class AdvancedSettingsManager: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { showAll in
                 Defaults.set(showAll, forKey: .showAllSectionsOnUserDrag)
+            }
+            .store(in: &c)
+
+        $showContextMenuOnRightClick
+            .receive(on: DispatchQueue.main)
+            .sink { showAll in
+                Defaults.set(showAll, forKey: .showContextMenuOnRightClick)
             }
             .store(in: &c)
 

--- a/Ice/Settings/SettingsPanes/AdvancedSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/AdvancedSettingsPane.swift
@@ -32,6 +32,7 @@ struct AdvancedSettingsPane: View {
                 hideApplicationMenus
                 showSectionDividers
                 showAllSectionsOnUserDrag
+                showContextMenuOnRightClick
             }
             IceSection {
                 enableAlwaysHiddenSection
@@ -136,6 +137,11 @@ struct AdvancedSettingsPane: View {
     @ViewBuilder
     private var showAllSectionsOnUserDrag: some View {
         Toggle("Show all sections when Command + dragging menu bar items", isOn: manager.bindings.showAllSectionsOnUserDrag)
+    }
+
+    @ViewBuilder
+    private var showContextMenuOnRightClick: some View {
+        Toggle("Show context menu on right click", isOn: manager.bindings.showContextMenuOnRightClick)
     }
 
     @ViewBuilder

--- a/Ice/Utilities/Defaults.swift
+++ b/Ice/Utilities/Defaults.swift
@@ -165,6 +165,7 @@ extension Defaults {
         case showOnHoverDelay = "ShowOnHoverDelay"
         case tempShowInterval = "TempShowInterval"
         case showAllSectionsOnUserDrag = "ShowAllSectionsOnUserDrag"
+        case showContextMenuOnRightClick = "ShowContextMenuOnRightClick"
 
         // MARK: Menu Bar Appearance Settings
 


### PR DESCRIPTION
<img width="252" alt="Screenshot 2025-03-21 at 5 54 22 PM" src="https://github.com/user-attachments/assets/320e34d0-7af2-4662-8471-f5bc9e6ab9f6" />

I have another app on the menu bar that has right click feature around the menubar region which will prompt the context menu from Ice as well. I don't use the context menu as well since I can just right click on the Ice menubar item to get into the settings. Thus, I created a config option to disable this context menu function. I currently placed it in advance settings, lmk if you want me to place somewhere else in the settings panel.

<img width="677" alt="Screenshot 2025-03-21 at 5 41 20 PM" src="https://github.com/user-attachments/assets/55035457-06ee-4a13-8241-db8a5fecd73b" />
