### PR TITLE
fix brew install command on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Download the "Ice.zip" file from the [latest release](https://github.com/jordanb
 Install Ice using the following command:
 
 ```sh
-brew install jordanbaird-ice
+brew install --cask jordanbaird-ice
 ```
 
 ## Features/Roadmap


### PR DESCRIPTION
Running `brew install jordanbaird-ice` was getting me the following error:

> Error: Download failed on Cask 'jordanbaird-ice' with message: Download failed: https://github.com/jordanbaird/ice-releases/releases/download/0.11.12/Ice.zip

On the brew link, I found the correct command that worked.

`brew install --cask jordanbaird-ice`