### PR TITLE
Multimonitor single space fix

### DIFF
--- a/Ice/Events/EventManager.swift
+++ b/Ice/Events/EventManager.swift
@@ -452,6 +452,11 @@ extension EventManager {
         else {
             return false
         }
+        
+        if !NSScreen.screensHaveSeparateSpaces && screen != NSScreen.screens.first {
+            return false
+        }
+
         if appState.menuBarManager.isMenuBarHiddenBySystem || appState.isActiveSpaceFullscreen {
             if
                 let mouseLocation = MouseCursor.locationCoreGraphics,


### PR DESCRIPTION
This checks to see if the "Screens have separate spaces" option is enabled and if so, checks to see if the current screen is the first screen. If so, continue. If not, it will return false.

Fixes #639