### PR TITLE
fix: Disable swizzling for macOS 26 and above to prevent crashes

### DIFF
--- a/Ice/Swizzling/NSSplitViewItem+swizzledCanCollapse.swift
+++ b/Ice/Swizzling/NSSplitViewItem+swizzledCanCollapse.swift
@@ -31,6 +31,10 @@ extension NSSplitViewItem {
     }
 
     static func swizzle() {
+        if #available(macOS 26, *) {
+            // Workaround: disable swizzle on macOS 26+ to avoid crash; minor UI issue is acceptable.
+            return
+        }
         _ = swizzler
     }
 }


### PR DESCRIPTION
This PR updates swizzle() to prevent crashes on macOS 26+ by skipping the swizzle entirely. A minor UI issue is accepted as a tradeoff to ensure stability.

Changes:
- Added #available(macOS 26, *) check.
- Disabled swizzling on macOS 26+, preserving behavior on earlier versions.