### PR TITLE
Add automatic Ice Bar toggle based on screen width threshold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .DS_Store
 build/
 xcuserdata/
+
+# https://github.com/jordanbaird/Ice/pull/795
+DerivedData/
+

--- a/Ice/Settings/SettingsManagers/GeneralSettingsManager.swift
+++ b/Ice/Settings/SettingsManagers/GeneralSettingsManager.swift
@@ -3,6 +3,7 @@
 //  Ice
 //
 
+import AppKit
 import Combine
 import Foundation
 
@@ -26,6 +27,17 @@ final class GeneralSettingsManager: ObservableObject {
     /// A Boolean value that indicates whether to show hidden items
     /// in a separate bar below the menu bar.
     @Published var useIceBar = false
+
+    /// A Boolean value that indicates whether Ice Bar should be
+    /// automatically enabled on built-in displays.
+    @Published var autoEnableIceBarOnBuiltInDisplay = false
+
+    /// The detection mode for automatic Ice Bar enabling.
+    @Published var iceBarAutoEnableMode: IceBarAutoEnableMode = .screenWidth
+
+    /// The screen width threshold (in pixels) below which Ice Bar is enabled.
+    /// Ice Bar will be enabled when screen width < threshold.
+    @Published var iceBarDisplayWidthThreshold: Double = 3000
 
     /// The location where the Ice Bar appears.
     @Published var iceBarLocation: IceBarLocation = .dynamic
@@ -78,12 +90,20 @@ final class GeneralSettingsManager: ObservableObject {
     func performSetup() {
         loadInitialState()
         configureCancellables()
+        observeScreenChanges()
     }
 
     private func loadInitialState() {
         Defaults.ifPresent(key: .showIceIcon, assign: &showIceIcon)
         Defaults.ifPresent(key: .customIceIconIsTemplate, assign: &customIceIconIsTemplate)
         Defaults.ifPresent(key: .useIceBar, assign: &useIceBar)
+        Defaults.ifPresent(key: .autoEnableIceBarOnBuiltInDisplay, assign: &autoEnableIceBarOnBuiltInDisplay)
+        Defaults.ifPresent(key: .iceBarAutoEnableMode) { rawValue in
+            if let mode = IceBarAutoEnableMode(rawValue: rawValue) {
+                iceBarAutoEnableMode = mode
+            }
+        }
+        Defaults.ifPresent(key: .iceBarDisplayWidthThreshold, assign: &iceBarDisplayWidthThreshold)
         Defaults.ifPresent(key: .showOnClick, assign: &showOnClick)
         Defaults.ifPresent(key: .showOnHover, assign: &showOnHover)
         Defaults.ifPresent(key: .showOnScroll, assign: &showOnScroll)
@@ -156,6 +176,32 @@ final class GeneralSettingsManager: ObservableObject {
             }
             .store(in: &c)
 
+        $autoEnableIceBarOnBuiltInDisplay
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] autoEnable in
+                Defaults.set(autoEnable, forKey: .autoEnableIceBarOnBuiltInDisplay)
+                if autoEnable {
+                    self?.updateIceBarForCurrentDisplay()
+                }
+            }
+            .store(in: &c)
+
+        $iceBarAutoEnableMode
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] mode in
+                Defaults.set(mode.rawValue, forKey: .iceBarAutoEnableMode)
+                self?.updateIceBarForCurrentDisplay()
+            }
+            .store(in: &c)
+
+        $iceBarDisplayWidthThreshold
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] threshold in
+                Defaults.set(threshold, forKey: .iceBarDisplayWidthThreshold)
+                self?.updateIceBarForCurrentDisplay()
+            }
+            .store(in: &c)
+
         $iceBarLocation
             .receive(on: DispatchQueue.main)
             .sink { location in
@@ -214,6 +260,38 @@ final class GeneralSettingsManager: ObservableObject {
             .store(in: &c)
 
         cancellables = c
+    }
+
+    /// Updates the Ice Bar setting based on the current display configuration.
+    private func updateIceBarForCurrentDisplay() {
+        guard autoEnableIceBarOnBuiltInDisplay else {
+            return
+        }
+
+        // Get the main screen (where the menu bar is)
+        guard let mainScreen = NSScreen.main else {
+            return
+        }
+
+        switch iceBarAutoEnableMode {
+        case .screenWidth:
+            // Enable Ice Bar if screen width is less than threshold
+            let screenWidth = mainScreen.frame.width
+            useIceBar = screenWidth < iceBarDisplayWidthThreshold
+        case .screensWithNotch:
+            // Enable Ice Bar only on screens with a notch
+            useIceBar = mainScreen.hasNotch
+        }
+    }
+
+    /// Sets up an observer for screen configuration changes.
+    func observeScreenChanges() {
+        NotificationCenter.default.publisher(for: NSApplication.didChangeScreenParametersNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.updateIceBarForCurrentDisplay()
+            }
+            .store(in: &cancellables)
     }
 }
 

--- a/Ice/Settings/SettingsPanes/GeneralSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/GeneralSettingsPane.swift
@@ -176,6 +176,13 @@ struct GeneralSettingsPane: View {
     @ViewBuilder
     private var iceBarOptions: some View {
         useIceBar
+        autoEnableIceBarToggle
+        if manager.autoEnableIceBarOnBuiltInDisplay {
+            onlyOnScreensWithNotchToggle
+            if manager.iceBarAutoEnableMode != .screensWithNotch {
+                widthThresholdInput
+            }
+        }
         if manager.useIceBar {
             iceBarLocationPicker
         }
@@ -185,6 +192,40 @@ struct GeneralSettingsPane: View {
     private var useIceBar: some View {
         Toggle("Use Ice Bar", isOn: manager.bindings.useIceBar)
             .annotation("Show hidden menu bar items in a separate bar below the menu bar")
+            .disabled(manager.autoEnableIceBarOnBuiltInDisplay)
+    }
+
+    @ViewBuilder
+    private var autoEnableIceBarToggle: some View {
+        Toggle(isOn: manager.bindings.autoEnableIceBarOnBuiltInDisplay) {
+            HStack {
+                Text("Auto-enable Ice Bar")
+                BetaBadge()
+            }
+        }
+        .annotation("Automatically enable or disable Ice Bar based on display")
+    }
+
+    @ViewBuilder
+    private var onlyOnScreensWithNotchToggle: some View {
+        Toggle("Only on screens with a notch", isOn: Binding(
+            get: { manager.iceBarAutoEnableMode == .screensWithNotch },
+            set: { manager.iceBarAutoEnableMode = $0 ? .screensWithNotch : .screenWidth }
+        ))
+        .annotation("Enable Ice Bar only on screens with a notch")
+    }
+
+    @ViewBuilder
+    private var widthThresholdInput: some View {
+        HStack {
+            Text("Width threshold:")
+            TextField("", value: manager.bindings.iceBarDisplayWidthThreshold, format: .number.grouping(.never))
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 80)
+            Text("pixels")
+                .foregroundStyle(.secondary)
+        }
+        .annotation("Ice Bar will be enabled when screen width is less than this value")
     }
 
     @ViewBuilder

--- a/Ice/UI/IceBar/IceBarAutoEnableMode.swift
+++ b/Ice/UI/IceBar/IceBarAutoEnableMode.swift
@@ -1,0 +1,26 @@
+//
+//  IceBarAutoEnableMode.swift
+//  Ice
+//
+//  See: https://github.com/jordanbaird/Ice/pull/795
+
+import SwiftUI
+
+/// Detection modes for automatic Ice Bar enabling.
+enum IceBarAutoEnableMode: Int, CaseIterable, Identifiable {
+    /// Enable Ice Bar when screen width is below a threshold.
+    case screenWidth = 0
+
+    /// Enable Ice Bar only on screens with a notch.
+    case screensWithNotch = 1
+
+    var id: Int { rawValue }
+
+    /// Localized string key representation.
+    var localized: LocalizedStringKey {
+        switch self {
+        case .screenWidth: "Screen width threshold"
+        case .screensWithNotch: "Screens with a notch"
+        }
+    }
+}

--- a/Ice/Utilities/Defaults.swift
+++ b/Ice/Utilities/Defaults.swift
@@ -175,6 +175,9 @@ extension Defaults {
 
         case iceBarLocation = "IceBarLocation"
         case iceBarPinnedLocation = "IceBarPinnedLocation"
+        case autoEnableIceBarOnBuiltInDisplay = "AutoEnableIceBarOnBuiltInDisplay"
+        case iceBarAutoEnableMode = "IceBarAutoEnableMode"
+        case iceBarDisplayWidthThreshold = "IceBarDisplayWidthThreshold"
 
         // MARK: Migration
 

--- a/Ice/Utilities/Extensions.swift
+++ b/Ice/Utilities/Extensions.swift
@@ -453,6 +453,11 @@ extension NSScreen {
         )
     }
 
+    /// A Boolean value that indicates whether the screen is a built-in display (laptop screen).
+    var isBuiltIn: Bool {
+        CGDisplayIsBuiltin(displayID) != 0
+    }
+
     /// Returns the height of the menu bar on this screen.
     func getMenuBarHeight() -> CGFloat? {
         let menuBarWindow = WindowInfo.getMenuBarWindow(for: displayID)


### PR DESCRIPTION
## Summary

This PR adds an automatic Ice Bar toggle feature that enables/disables Ice Bar based on screen width. Users can set a width threshold (in pixels), and Ice Bar will automatically enable when the screen width is below that threshold and disable when it's above.

## Screenshots

![SCR-20251124-ndka-2](https://github.com/user-attachments/assets/4779be6d-268b-403a-9b44-8d4badabb057)

<img width="893" height="414" alt="SCR-20251124-nekv-2" src="https://github.com/user-attachments/assets/2fd63554-dc9e-4d76-9a91-2f2ed43fcebf" />

## Motivation

When using Ice on multiple displays with different sizes, users currently need to manually toggle "Use Ice Bar" on and off. This becomes tedious when frequently switching between displays:

- On smaller displays (e.g., MacBook built-in screens), Ice Bar is useful for showing menu bar items under the notch
- On larger displays (e.g., ultrawide monitors), Ice Bar is unnecessary and can be distracting

This feature eliminates the manual toggling by automatically detecting screen width changes and adjusting the Ice Bar setting accordingly.

## How it works

1. User enables "Auto-enable on narrow displays" in Ice settings
2. User sets their desired width threshold (default is 3000 pixels)
3. When screen configuration changes (connecting/disconnecting displays, changing arrangements):
   - The app checks the main screen's width
   - If width < threshold: Ice Bar is enabled
   - If width >= threshold: Ice Bar is disabled
4. The change happens automatically without user intervention

## Testing

As I'm not a Swift expert and this is my first Apple app modification, I tested this feature locally by:

1. Building the app from Xcode with the feature branch
2. Granting necessary Accessibility and Screen Recording permissions
3. Verifying the new settings appear in the General settings pane
4. Testing the automatic toggle by:
   - Setting a width threshold of 3000 pixels
   - Enabling the auto-enable toggle
   - Testing with my Display Port disabled and MacBook Pro monitor enabled and vice versa

The feature compiled successfully and the UI appears as expected

## Notes for reviewers

- This is my first contribution to an Apple/Swift project, so please review carefully for any non-idiomatic code or potential issues
- This is PARTLY vibe coded as I am NOT experienced in Swift - please check for any mistakes
- Screen width is measured in logical points (accounting for Retina scaling), not physical pixels
- The feature uses macOS's native `NSApplication.didChangeScreenParametersNotification` to detect display changes

## Related issues

- #223
- #188

