### PR TITLE
fix(overlay-panel): menu bar clipping showing up on secondary monitor

### DIFF
--- a/Ice/MenuBar/Appearance/MenuBarOverlayPanel.swift
+++ b/Ice/MenuBar/Appearance/MenuBarOverlayPanel.swift
@@ -328,6 +328,12 @@ final class MenuBarOverlayPanel: NSPanel {
             return
         }
 
+        // Validate before showing to ensure panel should be visible on this screen.
+        let windows = WindowInfo.getOnScreenWindows()
+        guard validate(for: .showing, with: windows) != nil else {
+            return
+        }
+
         guard let menuBarHeight = owningScreen.getMenuBarHeight() else {
             return
         }


### PR DESCRIPTION
### Background
I have been using Ice for a couple of months, and I love it. The only thing that made me feel uncomfortable was the issue that was frequently mentioned in the community – menu bar clipping, which always floated on my external monitor when I turn my laptop's window full screen.

Since it's still not fixed yet, I would like to help and do a hotfix.

### Notes
- I'm not an iOS developer (I have little knowledge but not much), so I ask AI for help.
- I have done self-testing on my laptop and tried to fix this with minimal risk impact.
- I have left useful comments on the code change so that it could help the team better understand why this fix matters.

### Related Issues
- https://github.com/jordanbaird/Ice/issues/445
- https://github.com/jordanbaird/Ice/issues/521
- https://github.com/jordanbaird/Ice/issues/541
- https://github.com/jordanbaird/Ice/issues/576
- https://github.com/jordanbaird/Ice/issues/609
- https://github.com/jordanbaird/Ice/issues/636
- https://github.com/jordanbaird/Ice/issues/663
- https://github.com/jordanbaird/Ice/issues/772