### PR TITLE
fix(#530): Remove expired CGImages from cache

### DIFF
--- a/Ice/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Ice/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -212,7 +212,13 @@ final class MenuBarItemImageCache: ObservableObject {
             newImages.merge(sectionImages) { (_, new) in new }
         }
 
-        await MainActor.run { [newImages] in
+        // Get the set of valid item infos from all sections to clean up stale entries
+        let allValidInfos = await Set(appState.itemManager.itemCache.allItems.map(\.info))
+
+        await MainActor.run { [newImages, allValidInfos] in
+            // Remove images for items that no longer exist in the item cache
+            images = images.filter { allValidInfos.contains($0.key) }
+            // Merge in the new images
             images.merge(newImages) { (_, new) in new }
         }
 


### PR DESCRIPTION
Should fix Issue #530 On long-running systems, the CGImage cache would continue to grow.

On my system, after running for 15 days, the Cache is 983MB, almost half of the total memory usage.