### PR TITLE
Re-apply fix for Sparkle dialog buttons unresponsive

### DIFF
--- a/Ice/Utilities/MouseHelpers.swift
+++ b/Ice/Utilities/MouseHelpers.swift
@@ -1,5 +1,5 @@
 //
-//  MouseCursor.swift
+//  MouseHelpers.swift
 //  Ice
 //
 
@@ -43,6 +43,44 @@ enum MouseCursor {
         if result != .success {
             Logger.mouseCursor.error("CGWarpMouseCursorPosition failed with error \(result.logString)")
         }
+    }
+}
+
+// MARK: - MouseEvents
+
+/// A namespace for mouse event operations.
+enum MouseEvents {
+    /// Returns a Boolean value that indicates whether a mouse button
+    /// is pressed.
+    ///
+    /// - Parameter button: The mouse button to check. Pass `nil` to
+    ///   check all available mouse buttons (Quartz supports up to 32).
+    static func isButtonPressed(_ button: CGMouseButton? = nil) -> Bool {
+        let stateID = CGEventSourceStateID.combinedSessionState
+        if let button {
+            return CGEventSource.buttonState(stateID, button: button)
+        }
+        for n: UInt32 in 0...31 {
+            guard
+                let button = CGMouseButton(rawValue: n),
+                CGEventSource.buttonState(stateID, button: button)
+            else {
+                continue
+            }
+            return true
+        }
+        return false
+    }
+
+    /// Returns a Boolean value that indicates whether the last mouse
+    /// movement event occurred within the given duration.
+    ///
+    /// - Parameter interval: The duration within which the last mouse
+    ///   movement event must have occurred in order to return `true`.
+    static func lastMovementOccurred(within duration: Duration) -> Bool {
+        let stateID = CGEventSourceStateID.combinedSessionState
+        let seconds = CGEventSource.secondsSinceLastEventType(stateID, eventType: .mouseMoved)
+        return .seconds(seconds) <= duration
     }
 }
 


### PR DESCRIPTION
Fixes #681

This PR re-applies a fix that was accidentally reverted. I tested it locally and the Sparkle update window is responsive again.

In case I'm wrong with the accidental revert please let me know.
Same if there is something specific you want me to test.

### Timeline

1. **June 16, 2025** - Original fix applied in commit https://github.com/jordanbaird/Ice/commit/075581c
2. **July 21, 2025** - Accidentally reverted in commit https://github.com/jordanbaird/Ice/commit/eb5d14a ("Lots of refactoring")
3. **Now** - Re-applying the original fix via cherry-pick

### Changes

Cherry-picked commit https://github.com/jordanbaird/Ice/commit/075581c:

- Remove `RunLoopLocalEventMonitor` from continuous mouse tracking
- Add `MouseEvents` helper for checking mouse state
- Rename `MouseCursor.swift` → `MouseHelpers.swift`


