### PR TITLE
 Fix menu bar items not displaying when "Displays have separate spaces" is disabled

### DIFF
--- a/Shared/Bridging/Bridging.swift
+++ b/Shared/Bridging/Bridging.swift
@@ -113,17 +113,14 @@ extension Bridging {
 
     /// Returns the identifier of the display with the active menu bar.
     static func getActiveMenuBarDisplayID() -> CGDirectDisplayID? {
-        guard let string = CGSCopyActiveMenuBarDisplayIdentifier(getMainConnection()) else {
-            logger.error("CGSCopyActiveMenuBarDisplayIdentifier returned nil")
-            return nil
+        guard
+            let string = CGSCopyActiveMenuBarDisplayIdentifier(getMainConnection()),
+            let uuid = CFUUIDCreateFromString(nil, string.takeRetainedValue()),
+            let displayID = getActiveDisplayList().first(where: { getDisplayUUID(for: $0) == uuid })
+        else {
+            return CGMainDisplayID()
         }
-        guard let uuid = CFUUIDCreateFromString(nil, string.takeRetainedValue()) else {
-            logger.error("CFUUIDCreateFromString returned nil")
-            return nil
-        }
-        return getActiveDisplayList().first { displayID in
-            getDisplayUUID(for: displayID) == uuid
-        }
+        return displayID
     }
 }
 


### PR DESCRIPTION
- Update `Bridging.getActiveMenuBarDisplayID()` to fallback to `CGMainDisplayID()` if the active menu bar display cannot be determined via private API.
- This resolves issue #711 where the app failed to locate the correct display context in this specific macOS configuration, causing a cache failure.