### PR TITLE
Fix memory leaks and concurrency issues in menu bar item caching

### DIFF
--- a/Ice/MenuBar/MenuBarItems/MenuBarItem.swift
+++ b/Ice/MenuBar/MenuBarItems/MenuBarItem.swift
@@ -163,6 +163,7 @@ struct MenuBarItem: CustomStringConvertible {
     ///
     /// This initializer does not perform validity checks on its parameters.
     /// Only call it if you are certain the window is a valid menu bar item.
+    @MainActor
     private init(uncheckedItemWindow itemWindow: WindowInfo) {
         self.tag = MenuBarItemTag(uncheckedItemWindow: itemWindow)
         self.windowID = itemWindow.windowID
@@ -179,6 +180,7 @@ struct MenuBarItem: CustomStringConvertible {
     /// Only call it if you are certain the window is a valid menu bar item
     /// and the source pid belongs to the application that created it.
     @available(macOS 26.0, *)
+    @MainActor
     private init(uncheckedItemWindow itemWindow: WindowInfo, sourcePID: pid_t?) {
         self.tag = MenuBarItemTag(uncheckedItemWindow: itemWindow, sourcePID: sourcePID)
         self.windowID = itemWindow.windowID
@@ -243,6 +245,7 @@ extension MenuBarItem {
     /// Creates and returns a list of menu bar items using experimental
     /// source pid retrieval for macOS 26.
     @available(macOS 26.0, *)
+    @MainActor
     private static func getMenuBarItemsExperimental(on display: CGDirectDisplayID?, option: ListOption) async -> [MenuBarItem] {
         var items = [MenuBarItem]()
         for window in getMenuBarItemWindows(on: display, option: option) {
@@ -255,6 +258,7 @@ extension MenuBarItem {
 
     /// Creates and returns a list of menu bar items, defaulting to the
     /// legacy source pid behavior, prior to macOS 26.
+    @MainActor
     private static func getMenuBarItemsLegacyMethod(on display: CGDirectDisplayID?, option: ListOption) -> [MenuBarItem] {
         getMenuBarItemWindows(on: display, option: option).map { window in
             MenuBarItem(uncheckedItemWindow: window)
@@ -268,6 +272,7 @@ extension MenuBarItem {
     ///     items across all available displays.
     ///   - option: Options that filter the returned list. Pass an empty option set
     ///     to return all available menu bar items.
+    @MainActor
     static func getMenuBarItems(on display: CGDirectDisplayID? = nil, option: ListOption) async -> [MenuBarItem] {
         if #available(macOS 26.0, *) {
             await getMenuBarItemsExperimental(on: display, option: option)
@@ -310,6 +315,7 @@ private extension MenuBarItemTag {
     ///
     /// This initializer does not perform validity checks on its parameters.
     /// Only call it if you are certain the window is a valid menu bar item.
+    @MainActor
     init(uncheckedItemWindow itemWindow: WindowInfo) {
         self.namespace = Namespace(uncheckedItemWindow: itemWindow)
         self.title = itemWindow.title ?? ""
@@ -321,6 +327,7 @@ private extension MenuBarItemTag {
     /// Only call it if you are certain the window is a valid menu bar item
     /// and the source pid belongs to the application that created it.
     @available(macOS 26.0, *)
+    @MainActor
     init(uncheckedItemWindow itemWindow: WindowInfo, sourcePID: pid_t?) {
         self.namespace = Namespace(uncheckedItemWindow: itemWindow, sourcePID: sourcePID)
         self.title = itemWindow.title ?? ""
@@ -334,6 +341,7 @@ extension MenuBarItemTag.Namespace {
 
     /// Prunes the UUID cache, keeping only the entries for the given
     /// valid window identifiers.
+    @MainActor
     static func pruneUUIDCache(keeping validWindowIDs: Set<CGWindowID>) {
         uuidCache = uuidCache.filter { validWindowIDs.contains($0.key) }
     }
@@ -342,6 +350,7 @@ extension MenuBarItemTag.Namespace {
     ///
     /// This initializer does not perform validity checks on its parameters.
     /// Only call it if you are certain the window is a valid menu bar item.
+    @MainActor
     init(uncheckedItemWindow itemWindow: WindowInfo) {
         // Most apps have a bundle ID, but we should be able to handle apps
         // that don't. We should also be able to handle daemons and helpers,
@@ -363,6 +372,7 @@ extension MenuBarItemTag.Namespace {
     /// Only call it if you are certain the window is a valid menu bar item
     /// and the source pid belongs to the application that created it.
     @available(macOS 26.0, *)
+    @MainActor
     init(uncheckedItemWindow itemWindow: WindowInfo, sourcePID: pid_t?) {
         // Most apps have a bundle ID, but we should be able to handle apps
         // that don't. We should also be able to handle daemons and helpers,

--- a/Ice/MenuBar/MenuBarItems/MenuBarItem.swift
+++ b/Ice/MenuBar/MenuBarItems/MenuBarItem.swift
@@ -329,8 +329,14 @@ private extension MenuBarItemTag {
 
 // MARK: - MenuBarItemTag.Namespace Helper
 
-private extension MenuBarItemTag.Namespace {
+extension MenuBarItemTag.Namespace {
     private static var uuidCache = [CGWindowID: UUID]()
+
+    /// Prunes the UUID cache, keeping only the entries for the given
+    /// valid window identifiers.
+    static func pruneUUIDCache(keeping validWindowIDs: Set<CGWindowID>) {
+        uuidCache = uuidCache.filter { validWindowIDs.contains($0.key) }
+    }
 
     /// Creates a namespace without checks.
     ///

--- a/Ice/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Ice/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -264,7 +264,13 @@ final class MenuBarItemImageCache: ObservableObject {
             newImages.merge(sectionImages) { (_, new) in new }
         }
 
-        await MainActor.run { [newImages] in
+        // Get the set of valid item infos from all sections to clean up stale entries
+        let allValidInfos = await Set(appState.itemManager.itemCache.allItems.map(\.info))
+
+        await MainActor.run { [newImages, allValidInfos] in
+            // Remove images for items that no longer exist in the item cache
+            images = images.filter { allValidInfos.contains($0.key) }
+            // Merge in the new images
             images.merge(newImages) { (_, new) in new }
         }
     }

--- a/Ice/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Ice/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -264,12 +264,12 @@ final class MenuBarItemImageCache: ObservableObject {
             newImages.merge(sectionImages) { (_, new) in new }
         }
 
-        // Get the set of valid item infos from all sections to clean up stale entries
-        let allValidInfos = await Set(appState.itemManager.itemCache.allItems.map(\.info))
+        // Get the set of valid item tags from all sections to clean up stale entries
+        let allValidTags = await Set(appState.itemManager.itemCache.managedItems.map(\.tag))
 
-        await MainActor.run { [newImages, allValidInfos] in
+        await MainActor.run { [newImages, allValidTags] in
             // Remove images for items that no longer exist in the item cache
-            images = images.filter { allValidInfos.contains($0.key) }
+            images = images.filter { allValidTags.contains($0.key) }
             // Merge in the new images
             images.merge(newImages) { (_, new) in new }
         }

--- a/Ice/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Ice/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -356,6 +356,8 @@ extension MenuBarItemManager {
             let itemWindowIDs = currentItemWindowIDs ?? items.reversed().map { $0.windowID }
             await cacheActor.updateCachedItemWindowIDs(itemWindowIDs)
 
+            MenuBarItemTag.Namespace.pruneUUIDCache(keeping: Set(itemWindowIDs))
+
             guard let controlItems = ControlItemPair(items: &items) else {
                 // ???: Is clearing the cache the best thing to do here?
                 logger.warning("Missing control item for hidden section, clearing menu bar item cache")


### PR DESCRIPTION
This PR addresses several memory leaks and concurrency issues in the menu bar item caching system. It is based on PR #804 by @mrunkel

- Fix memory leaks in cache:
   - Added pruneUUIDCache to MenuBarItemTag.Namespace to remove stale UUID entries for windows that no longer exist, preventing unbounded growth.
   - Added pruneMoveOperationTimeouts to MenuBarItemManager to clean up old timeout values for items that are no longer managed.
   - Corrected cleanup logic in MenuBarItemImageCache to properly access managedItems and remove stale images, fixing a build error and potential leak.

- Fix concurrency issues:
   - Enforced `@MainActor` isolation on MenuBarItem and MenuBarItemTag initializers.
   - Propagated `@MainActor` requirements to getMenuBarItems and helper methods to ensure thread-safe access to shared static caches and prevent data races.