### PR TITLE
Update Ifrit to v4.0.0 and persist Search Window position

### DIFF
--- a/Ice.xcodeproj/project.pbxproj
+++ b/Ice.xcodeproj/project.pbxproj
@@ -595,7 +595,7 @@
 			repositoryURL = "https://github.com/ukushu/Ifrit";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.3;
+				minimumVersion = 4.0.0;
 			};
 		};
 		71A065072E680C620087DB38 /* XCRemoteSwiftPackageReference "Semaphore" */ = {

--- a/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Ice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ukushu/Ifrit",
       "state" : {
-        "revision" : "3f961f6d39cd2188305671f2ec65914d297571d0",
-        "version" : "2.0.6"
+        "revision" : "7c889a67bad90c5efefa56889b2d61bfbb831473",
+        "version" : "4.0.0"
       }
     },
     {

--- a/Ice/MenuBar/Search/MenuBarSearchPanel.swift
+++ b/Ice/MenuBar/Search/MenuBarSearchPanel.swift
@@ -157,16 +157,41 @@ final class MenuBarSearchPanel: NSPanel {
                 // and it's on the correct screen if requested
                 var newFrame = savedFrame
                 newFrame.size = hostingView.intrinsicContentSize
+
+                if let savedScreen = NSScreen.screens.first(where: { $0.frame.intersects(savedFrame) }) {
+                    // Calculate relative center position (0.0 to 1.0) based on visible frame (excluding menu bar)
+                    let savedVisibleFrame = savedScreen.visibleFrame
+                    let relMidX = (savedFrame.midX - savedVisibleFrame.minX) / savedVisibleFrame.width
+                    let relMidY = (savedFrame.midY - savedVisibleFrame.minY) / savedVisibleFrame.height
+
+                    // Apply to new screen's visible frame to get new center
+                    let currentVisibleFrame = screen.visibleFrame
+                    let newMidX = currentVisibleFrame.minX + (relMidX * currentVisibleFrame.width)
+                    let newMidY = currentVisibleFrame.minY + (relMidY * currentVisibleFrame.height)
+
+                    // Calculate new origin based on new center and window size
+                    let newOriginX = newMidX - (newFrame.width / 2)
+                    let newOriginY = newMidY - (newFrame.height / 2)
+
+                    newFrame.origin = CGPoint(x: newOriginX, y: newOriginY)
+                } else {
+                    let centered = CGPoint(
+                        x: screen.frame.midX - newFrame.width / 2,
+                        y: screen.frame.midY - newFrame.height / 2
+                    )
+                    newFrame.origin = centered
+                }
+
                 setFrame(newFrame, display: false)
             } else {
                 // Calculate the centered position.
                 let centered = CGPoint(
-                    x: screen.frame.midX - frame.width / 2,
-                    y: screen.frame.midY - frame.height / 2
+                    x: screen.frame.midX - hostingView.intrinsicContentSize.width / 2,
+                    y: screen.frame.midY - hostingView.intrinsicContentSize.height / 2
                 )
 
                 setFrame(CGRect(origin: centered, size: hostingView.intrinsicContentSize), display: false)
-                center()
+                // center() // Not needed if we calculated it manually
             }
 
             contentView = hostingView

--- a/Ice/UI/Views/SectionedList.swift
+++ b/Ice/UI/Views/SectionedList.swift
@@ -158,14 +158,14 @@ extension SectionedList {
 // MARK: - SectionedListItem
 
 /// An item in a sectioned list.
-struct SectionedListItem<ID: Hashable> {
+struct SectionedListItem<ID: Hashable>: @unchecked Sendable {
     let content: AnyView
     let id: ID
     let isSelectable: Bool
-    let action: (() -> Void)?
+    let action: (@MainActor @Sendable () -> Void)?
 
     /// Returns a selectable item for a sectioned list.
-    static func item(id: ID, isSelectable: Bool = true, action: (() -> Void)? = nil, @ViewBuilder content: () -> some View) -> SectionedListItem {
+    static func item(id: ID, isSelectable: Bool = true, action: (@MainActor @Sendable () -> Void)? = nil, @ViewBuilder content: () -> some View) -> SectionedListItem {
         SectionedListItem(content: AnyView(content()), id: id, isSelectable: isSelectable, action: action)
     }
 

--- a/Ice/Utilities/Defaults.swift
+++ b/Ice/Utilities/Defaults.swift
@@ -163,6 +163,9 @@ extension Defaults {
         case showOnHoverDelay = "ShowOnHoverDelay"
         case tempShowInterval = "TempShowInterval"
 
+        // MARK: Internal
+        case menuBarSearchPanelFrame = "MenuBarSearchPanelFrame"
+
         // MARK: Appearance Settings
         case menuBarAppearanceConfigurationV2 = "MenuBarAppearanceConfigurationV2"
 


### PR DESCRIPTION
This PR updates the search dependency to Ifrit v4.0.0 and ensures the Menu Bar Search window remembers its position on screen, even after restarting the app.

- Ifrit v4.0.0
   - Migrated search logic to use the new `Fuse` API and `Searchable` protocol.
   - Fixed build errors by replacing removed helpers (like `bestMatch`) with native `Fuse.searchSync`.
   - Addressed Swift 6 concurrency warnings in `SectionedListItem`.

- Search Window Persistence
   - The Search Window now reliably remembers its last position across sessions.
   - Implemented manual frame storage in `UserDefaults`, replacing the previous `NSWindow` autosave mechanism which was failing to restore the position after app restarts.