### PR TITLE
Feature: Option to show Ice Bar only on built-in display

### DIFF
--- a/Ice/Events/HIDEventManager.swift
+++ b/Ice/Events/HIDEventManager.swift
@@ -382,7 +382,7 @@ extension HIDEventManager {
     private func handlePreventShowOnHover(with event: NSEvent, appState: AppState, screen: NSScreen) {
         guard
             appState.settings.general.showOnHover,
-            !appState.settings.general.useIceBar
+            !appState.settings.general.useIceBar(for: screen)
         else {
             return
         }

--- a/Ice/MenuBar/MenuBarManager.swift
+++ b/Ice/MenuBar/MenuBarManager.swift
@@ -161,8 +161,9 @@ final class MenuBarManager: ObservableObject {
                 //   * The active space is fullscreen.
                 //   * The settings window is visible.
                 guard
+                    let screen = NSScreen.main,
                     appState.settings.advanced.hideApplicationMenus,
-                    !appState.settings.general.useIceBar,
+                    !appState.settings.general.useIceBar(for: screen),
                     !isMenuBarHiddenBySystem,
                     !appState.activeSpace.isFullscreen,
                     !appState.navigationState.isSettingsPresented
@@ -171,10 +172,6 @@ final class MenuBarManager: ObservableObject {
                 }
 
                 if sections.contains(where: { $0.controlItem.state == .showSection }) {
-                    guard let screen = NSScreen.main else {
-                        return
-                    }
-
                     // Get the application menu frame for the display.
                     guard let applicationMenuFrame = screen.getApplicationMenuFrame() else {
                         return

--- a/Ice/MenuBar/MenuBarSection.swift
+++ b/Ice/MenuBar/MenuBarSection.swift
@@ -55,8 +55,8 @@ final class MenuBarSection {
     private var rehideMonitor: EventMonitor?
 
     /// A Boolean value that indicates whether the Ice Bar should be used.
-    private var useIceBar: Bool {
-        appState?.settings.general.useIceBar ?? false
+    private func useIceBar(for screen: NSScreen) -> Bool {
+        appState?.settings.general.useIceBar(for: screen) ?? false
     }
 
     /// A weak reference to the menu bar manager.
@@ -78,7 +78,10 @@ final class MenuBarSection {
 
     /// A Boolean value that indicates whether the section is hidden.
     var isHidden: Bool {
-        if useIceBar {
+        guard let screen = screenForIceBar ?? NSScreen.main else {
+            return true
+        }
+        if useIceBar(for: screen) {
             if controlItem.state == .showSection {
                 return false
             }
@@ -161,7 +164,11 @@ final class MenuBarSection {
             return
         }
 
-        if useIceBar {
+        guard let screen = screenForIceBar ?? NSScreen.main else {
+            return
+        }
+
+        if useIceBar(for: screen) {
             // Make sure hidden and always-hidden control items are collapsed.
             // Still update the visible control item (Ice icon) state to show
             // its alternate icon.
@@ -174,16 +181,14 @@ final class MenuBarSection {
                 }
             }
 
-            if let screen = screenForIceBar {
-                Task {
-                    switch name {
-                    case .visible, .hidden:
-                        await menuBarManager.iceBarPanel.show(section: .hidden, on: screen)
-                    case .alwaysHidden:
-                        await menuBarManager.iceBarPanel.show(section: .alwaysHidden, on: screen)
-                    }
-                    startRehideChecks()
+            Task {
+                switch name {
+                case .visible, .hidden:
+                    await menuBarManager.iceBarPanel.show(section: .hidden, on: screen)
+                case .alwaysHidden:
+                    await menuBarManager.iceBarPanel.show(section: .alwaysHidden, on: screen)
                 }
+                startRehideChecks()
             }
 
             return // We're done.
@@ -216,8 +221,12 @@ final class MenuBarSection {
         menuBarManager.iceBarPanel.close() // Make sure Ice Bar is always closed.
         menuBarManager.showOnHoverAllowed = true
 
+        guard let screen = screenForIceBar ?? NSScreen.main else {
+            return
+        }
+
         switch name {
-        case _ where useIceBar, .visible, .hidden:
+        case _ where useIceBar(for: screen), .visible, .hidden:
             for section in menuBarManager.sections {
                 section.controlItem.state = .hideSection
             }

--- a/Ice/Settings/Models/GeneralSettings.swift
+++ b/Ice/Settings/Models/GeneralSettings.swift
@@ -31,6 +31,10 @@ final class GeneralSettings: ObservableObject {
     /// in a separate bar below the menu bar.
     @Published var useIceBar = false
 
+    /// A Boolean value that indicates whether to use the Ice Bar
+    /// only on the internal display.
+    @Published var iceBarOnInternalDisplayOnly = false
+
     /// The location where the Ice Bar appears.
     @Published var iceBarLocation: IceBarLocation = .dynamic
 
@@ -75,6 +79,12 @@ final class GeneralSettings: ObservableObject {
     /// The shared app state.
     private(set) weak var appState: AppState?
 
+    /// Returns a Boolean value that indicates whether the Ice Bar
+    /// should be used on the given screen.
+    func useIceBar(for screen: NSScreen) -> Bool {
+        useIceBar && (!iceBarOnInternalDisplayOnly || screen.isBuiltIn)
+    }
+
     /// Performs the initial setup of the model.
     func performSetup(with appState: AppState) {
         self.appState = appState
@@ -87,6 +97,7 @@ final class GeneralSettings: ObservableObject {
         Defaults.ifPresent(key: .showIceIcon, assign: &showIceIcon)
         Defaults.ifPresent(key: .customIceIconIsTemplate, assign: &customIceIconIsTemplate)
         Defaults.ifPresent(key: .useIceBar, assign: &useIceBar)
+        Defaults.ifPresent(key: .iceBarOnInternalDisplayOnly, assign: &iceBarOnInternalDisplayOnly)
         Defaults.ifPresent(key: .showOnClick, assign: &showOnClick)
         Defaults.ifPresent(key: .showOnHover, assign: &showOnHover)
         Defaults.ifPresent(key: .showOnScroll, assign: &showOnScroll)
@@ -157,6 +168,13 @@ final class GeneralSettings: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { useIceBar in
                 Defaults.set(useIceBar, forKey: .useIceBar)
+            }
+            .store(in: &c)
+
+        $iceBarOnInternalDisplayOnly
+            .receive(on: DispatchQueue.main)
+            .sink { iceBarOnInternalDisplayOnly in
+                Defaults.set(iceBarOnInternalDisplayOnly, forKey: .iceBarOnInternalDisplayOnly)
             }
             .store(in: &c)
 

--- a/Ice/Settings/SettingsPanes/GeneralSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/GeneralSettingsPane.swift
@@ -176,8 +176,15 @@ struct GeneralSettingsPane: View {
     private var iceBarOptions: some View {
         useIceBar
         if settings.useIceBar {
+            iceBarOnInternalDisplayOnly
             iceBarLocationPicker
         }
+    }
+
+    @ViewBuilder
+    private var iceBarOnInternalDisplayOnly: some View {
+        Toggle("Only on internal display", isOn: $settings.iceBarOnInternalDisplayOnly)
+            .annotation("Only use the Ice Bar on the internal display.")
     }
 
     @ViewBuilder

--- a/Ice/Utilities/Defaults.swift
+++ b/Ice/Utilities/Defaults.swift
@@ -142,6 +142,7 @@ extension Defaults {
         case iceIcon = "IceIcon"
         case customIceIconIsTemplate = "CustomIceIconIsTemplate"
         case useIceBar = "UseIceBar"
+        case iceBarOnInternalDisplayOnly = "IceBarOnInternalDisplayOnly"
         case iceBarLocation = "IceBarLocation"
         case showOnClick = "ShowOnClick"
         case showOnHover = "ShowOnHover"

--- a/Ice/Utilities/Extensions.swift
+++ b/Ice/Utilities/Extensions.swift
@@ -522,6 +522,11 @@ extension NSScreen {
         deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as! CGDirectDisplayID
     }
 
+    /// A Boolean value that indicates whether the screen is the built-in display.
+    var isBuiltIn: Bool {
+        CGDisplayIsBuiltin(displayID) != 0
+    }
+
     /// A Boolean value that indicates whether the screen has a notch.
     var hasNotch: Bool {
         safeAreaInsets.top != 0


### PR DESCRIPTION
This adds a new configuration option that allows the Ice Bar to only be displayed on the built-in display. This is mostly for notched devices with external displays connected.

**Changes:**
- Settings: Added a new "Only on internal display" toggle under the Ice Bar section in GeneralSettingsPane.
- Core Logic:
    - Added NSScreen.isBuiltIn extension using CGDisplayIsBuiltin.
    - Updated MenuBarSection, MenuBarManager, and HIDEventManager to be screen-aware when determining whether to render the secondary bar.