### PR TITLE
Add option to disable right-click menu bar overlay

### DIFF
--- a/Ice/Events/EventManager.swift
+++ b/Ice/Events/EventManager.swift
@@ -24,6 +24,9 @@ final class EventManager {
         guard let self else {
             return event
         }
+        if handleOpenSettingsFallback(with: event) {
+            return event
+        }
         switch event.type {
         case .leftMouseDown:
             handleShowOnClick()
@@ -263,6 +266,27 @@ extension EventManager {
             return
         }
         appState.menuBarManager.showRightClickMenu(at: mouseLocation)
+    }
+
+    // MARK: Handle Open Settings Fallback
+
+    private func handleOpenSettingsFallback(with event: NSEvent) -> Bool {
+        guard
+            let appState,
+            !appState.settingsManager.advancedSettingsManager.showContextMenuOnRightClick,
+            event.type == .leftMouseDown || event.type == .rightMouseDown,
+            isMouseInsideMenuBar
+        else {
+            return false
+        }
+
+        let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        guard modifiers.contains([.option, .command]) else {
+            return false
+        }
+
+        appState.appDelegate?.openSettingsWindow()
+        return true
     }
 
     // MARK: Handle Prevent Show On Hover

--- a/Ice/MenuBar/ControlItem/ControlItem.swift
+++ b/Ice/MenuBar/ControlItem/ControlItem.swift
@@ -394,12 +394,17 @@ final class ControlItem {
         else {
             return
         }
+        let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let showContextMenus = appState.settingsManager.advancedSettingsManager.showContextMenuOnRightClick
         switch event.type {
         case .leftMouseDown, .leftMouseUp:
-            if NSEvent.modifierFlags == .control {
+            if
+                modifiers == .control,
+                showContextMenus
+            {
                 statusItem.showMenu(createMenu(with: appState))
             } else if
-                NSEvent.modifierFlags == .option,
+                modifiers == .option,
                 appState.settingsManager.advancedSettingsManager.canToggleAlwaysHiddenSection
             {
                 if let alwaysHiddenSection = appState.menuBarManager.section(withName: .alwaysHidden) {
@@ -409,6 +414,9 @@ final class ControlItem {
                 section?.toggle()
             }
         case .rightMouseUp:
+            guard showContextMenus else {
+                return
+            }
             statusItem.showMenu(createMenu(with: appState))
         default:
             break

--- a/Ice/Settings/SettingsPanes/AdvancedSettingsPane.swift
+++ b/Ice/Settings/SettingsPanes/AdvancedSettingsPane.swift
@@ -141,7 +141,8 @@ struct AdvancedSettingsPane: View {
 
     @ViewBuilder
     private var showContextMenuOnRightClick: some View {
-        Toggle("Show context menu on right click", isOn: manager.bindings.showContextMenuOnRightClick)
+        Toggle("Show Ice context menus on right click", isOn: manager.bindings.showContextMenuOnRightClick)
+            .annotation("Disable this to ignore Ice right-click menus for better compatibility with apps like DynamicLake. When disabled, Option + Command + click in the menu bar opens Ice settings.")
     }
 
     @ViewBuilder


### PR DESCRIPTION
- Add Advanced setting to disable Ice's right-click menu bar menu
- When enabled, right-click no longer shows 'Edit Menu Bar Appearance' and 'Ice Settings'
- Keep access via ⌥⌘-click as an alternative entry point
- Improves compatibility with apps like DynamicLake