### PR TITLE
Fix "Unable to display
  menu bar items" on macOS 26.4

### DIFF
--- a/Shared/Bridging/Bridging.swift
+++ b/Shared/Bridging/Bridging.swift
@@ -113,17 +113,15 @@ extension Bridging {
 
     /// Returns the identifier of the display with the active menu bar.
     static func getActiveMenuBarDisplayID() -> CGDirectDisplayID? {
-        guard let string = CGSCopyActiveMenuBarDisplayIdentifier(getMainConnection()) else {
-            logger.error("CGSCopyActiveMenuBarDisplayIdentifier returned nil")
-            return nil
+        if let string = CGSCopyActiveMenuBarDisplayIdentifier(getMainConnection()),
+           let uuid = CFUUIDCreateFromString(nil, string.takeRetainedValue()),
+           let id = getActiveDisplayList().first(where: { getDisplayUUID(for: $0) == uuid }) {
+            return id
         }
-        guard let uuid = CFUUIDCreateFromString(nil, string.takeRetainedValue()) else {
-            logger.error("CFUUIDCreateFromString returned nil")
-            return nil
-        }
-        return getActiveDisplayList().first { displayID in
-            getDisplayUUID(for: displayID) == uuid
-        }
+        // CGSCopyActiveMenuBarDisplayIdentifier returns nil on macOS 26.4.1.
+        let fallback = CGMainDisplayID()
+        logger.warning("CGSCopyActiveMenuBarDisplayIdentifier unavailable, using CGMainDisplayID=\(fallback, privacy: .public)")
+        return fallback
     }
 }
 


### PR DESCRIPTION
Fixes the empty Menu Bar Layout pane on macOS 26.4 / 26.4.1. Likely fixes #913 and #916, possibly #891 and #921.

On macOS 26.4.1 (build 25E253), `CGSCopyActiveMenuBarDisplayIdentifier` returns nil. That cascades:

1. `Bridging.getActiveMenuBarDisplayID()` returns nil
2. `MenuBarItemManager.ItemCache.displayID` stays nil after `cacheItemsRegardless`
3. `MenuBarItemImageCache.updateCacheWithoutChecks` bails on its `guard let displayID` check (silently, no log)
4. `cacheFailed(for:)` returns true for every section because items were cached but no images
5. The Layout pane renders "Unable to display menu bar items"

Items themselves enumerate fine (20 items in my case) and `cacheItemsRegardless` reaches `Updated menu bar item cache` -- only the displayID is nil. 

This PR adds a `CGMainDisplayID()` fallback in `getActiveMenuBarDisplayID`. Verified on a single-display setup running 26.4.1; the layout pane populates correctly. Multi-display configurations with the menu bar on a non-main display may need a richer fallback (for example, the NSScreen whose frame intersects the menu-bar window's frame), but `CGMainDisplayID()` is strictly better than nil in every case.

### Test plan

- [x] Build `macos-26` clean on macOS 26.4.1, observe the empty Layout pane
- [x] Apply the patch, rebuild, observe the populated Layout pane
- [ ] Multi-display config -- not tested
