### PR TITLE
Skip show-on-click when an overlay covers the menu bar

### DIFF
--- a/Ice/Events/EventManager.swift
+++ b/Ice/Events/EventManager.swift
@@ -516,7 +516,25 @@ extension EventManager {
         isMouseInsideMenuBar &&
         !isMouseInsideApplicationMenu &&
         !isMouseInsideMenuBarItem &&
-        !isMouseInsideNotch
+        !isMouseInsideNotch &&
+        !isMouseInsideOverlayAboveMenuBar
+    }
+
+    /// A Boolean value that indicates whether the mouse pointer is occluded
+    /// by a third-party window whose level is above the menu bar.
+    var isMouseInsideOverlayAboveMenuBar: Bool {
+        guard let mouseLocation = MouseCursor.locationCoreGraphics else {
+            return false
+        }
+        let pid = ProcessInfo.processInfo.processIdentifier
+        let menuBarLevel = Int(CGWindowLevelForKey(.mainMenuWindow))
+        let cursorLevel = Int(CGWindowLevelForKey(.cursorWindow))
+        return WindowInfo.getOnScreenWindows(excludeDesktopWindows: true).contains { window in
+            window.ownerPID != pid &&
+            window.layer > menuBarLevel &&
+            window.layer < cursorLevel &&
+            window.frame.contains(mouseLocation)
+        }
     }
 
     /// A Boolean value that indicates whether the mouse pointer is within


### PR DESCRIPTION
 isMouseInsideEmptyMenuBarSpace already excludes the hardware notch, but it doesn't account for third‑party windows whose level sits above the menu bar (e.g. notch‑extension apps like boring.notch, which uses level = .mainMenu + 3). When the user clicks one of those overlays' UI elements, Ice's NSEvent global monitor fires (the click was delivered to "another app"), the overlap with the menu‑bar Y range satisfies isMouseInsideMenuBar, none of the existing exclusions match and Show on Click toggles a hidden section even though the user never clicked the menu bar.

This adds a generic gate that asks the WindowServer for windows occluding the click point above menu‑bar level (and below the cursor), excluding Ice's own windows. If one is found, the click is treated as not inside an empty menu bar space.

  Repro
  1. Install boring.notch (or any app with a window at NSWindow.Level.mainMenu + N).
  2. Enable Settings -> General -> Show on Click in Ice.
  3. Hide a section so it's available to toggle.
  4. Click any control inside the boring.notch UI (e.g. the shelf tab).
  5. Before this change: the hidden section toggles. After: it doesn't.