### PR TITLE
fix(xpc): make MenuBarItemService work for ad-hoc-signed builds on macOS 26

### DIFF
--- a/Ice/MenuBar/MenuBarItems/MenuBarItemServiceConnection.swift
+++ b/Ice/MenuBar/MenuBarItems/MenuBarItemServiceConnection.swift
@@ -104,7 +104,16 @@ extension MenuBarItemService {
                     logger.warning("Session was cancelled with error \(error.localizedDescription)")
                     self.session = nil
                 }
-                session.setPeerRequirement(.isFromSameTeam())
+                // Same logic as MenuBarItemService/Listener.swift's listener-side
+                // guard: only enforce `.isFromSameTeam()` when we actually have
+                // a team identifier. Ad-hoc-signed builds (every community fork
+                // without an Apple Developer Program account) have no team
+                // identifier and would silently reject our own helper service
+                // — making the Menu Bar Layout pane spin forever on
+                // "Loading menu bar items…" (upstream issues #744 and #891).
+                if MenuBarItemService.ownTeamIdentifier() != nil {
+                    session.setPeerRequirement(.isFromSameTeam())
+                }
                 session.setTargetQueue(queue)
                 try session.activate()
                 self.session = session

--- a/MenuBarItemService/Listener.swift
+++ b/MenuBarItemService/Listener.swift
@@ -4,7 +4,6 @@
 //
 
 import OSLog
-import Security
 import XPC
 
 /// A wrapper around an XPC listener object.
@@ -23,38 +22,6 @@ final class Listener {
 
     deinit {
         cancel()
-    }
-
-    /// Returns the Team Identifier of the currently running process, or
-    /// `nil` if the binary is unsigned, ad-hoc signed, or the team
-    /// identifier cannot be read.
-    ///
-    /// We need this because `.isFromSameTeam()` (used on macOS 26+ to
-    /// constrain XPC peers) silently rejects every connection when the
-    /// service binary has no team identifier — which is the case for any
-    /// ad-hoc-signed build, including community forks that ship without
-    /// an Apple Developer Program account. Without this check the XPC
-    /// service rejects its own parent app with "Bogus check-in attempt",
-    /// and the Menu Bar Layout pane spins forever on
-    /// "Loading menu bar items…".
-    private static func ownTeamIdentifier() -> String? {
-        var staticCode: SecStaticCode?
-        guard
-            SecStaticCodeCreateWithPath(Bundle.main.bundleURL as CFURL, [], &staticCode) == errSecSuccess,
-            let code = staticCode
-        else {
-            return nil
-        }
-        var info: CFDictionary?
-        guard
-            SecCodeCopySigningInformation(code, SecCSFlags(rawValue: 0), &info) == errSecSuccess,
-            let dict = info as? [String: Any],
-            let teamID = dict[kSecCodeInfoTeamIdentifier as String] as? String,
-            !teamID.isEmpty
-        else {
-            return nil
-        }
-        return teamID
     }
 
     /// Handles a received message.
@@ -111,8 +78,11 @@ final class Listener {
             // identifier to compare against. Ad-hoc-signed builds (every
             // community fork without an Apple Developer Program account)
             // have no team identifier and would reject every connection
-            // — including their own parent app — silently.
-            if #available(macOS 26.0, *), Self.ownTeamIdentifier() != nil {
+            // — including their own parent app — silently. The shared
+            // helper lives on MenuBarItemService so the matching guard
+            // in MenuBarItemServiceConnection (the client side) uses
+            // exactly the same predicate.
+            if #available(macOS 26.0, *), MenuBarItemService.ownTeamIdentifier() != nil {
                 try uncheckedActivateWithSameTeamRequirement()
             } else {
                 try uncheckedActivate()

--- a/MenuBarItemService/Listener.swift
+++ b/MenuBarItemService/Listener.swift
@@ -4,6 +4,7 @@
 //
 
 import OSLog
+import Security
 import XPC
 
 /// A wrapper around an XPC listener object.
@@ -22,6 +23,38 @@ final class Listener {
 
     deinit {
         cancel()
+    }
+
+    /// Returns the Team Identifier of the currently running process, or
+    /// `nil` if the binary is unsigned, ad-hoc signed, or the team
+    /// identifier cannot be read.
+    ///
+    /// We need this because `.isFromSameTeam()` (used on macOS 26+ to
+    /// constrain XPC peers) silently rejects every connection when the
+    /// service binary has no team identifier — which is the case for any
+    /// ad-hoc-signed build, including community forks that ship without
+    /// an Apple Developer Program account. Without this check the XPC
+    /// service rejects its own parent app with "Bogus check-in attempt",
+    /// and the Menu Bar Layout pane spins forever on
+    /// "Loading menu bar items…".
+    private static func ownTeamIdentifier() -> String? {
+        var staticCode: SecStaticCode?
+        guard
+            SecStaticCodeCreateWithPath(Bundle.main.bundleURL as CFURL, [], &staticCode) == errSecSuccess,
+            let code = staticCode
+        else {
+            return nil
+        }
+        var info: CFDictionary?
+        guard
+            SecCodeCopySigningInformation(code, SecCSFlags(rawValue: 0), &info) == errSecSuccess,
+            let dict = info as? [String: Any],
+            let teamID = dict[kSecCodeInfoTeamIdentifier as String] as? String,
+            !teamID.isEmpty
+        else {
+            return nil
+        }
+        return teamID
     }
 
     /// Handles a received message.
@@ -73,7 +106,13 @@ final class Listener {
         Logger.default.debug("Activating listener")
 
         do {
-            if #available(macOS 26.0, *) {
+            // On macOS 26+ the listener can constrain peers by team
+            // identifier, but only when we actually have a team
+            // identifier to compare against. Ad-hoc-signed builds (every
+            // community fork without an Apple Developer Program account)
+            // have no team identifier and would reject every connection
+            // — including their own parent app — silently.
+            if #available(macOS 26.0, *), Self.ownTeamIdentifier() != nil {
                 try uncheckedActivateWithSameTeamRequirement()
             } else {
                 try uncheckedActivate()

--- a/Shared/Services/MenuBarItemService.swift
+++ b/Shared/Services/MenuBarItemService.swift
@@ -4,9 +4,44 @@
 //
 
 import Foundation
+import Security
 
 enum MenuBarItemService {
     static let name = "com.jordanbaird.Ice.MenuBarItemService"
+
+    /// Returns the Team Identifier of the currently running process, or
+    /// `nil` if the binary is unsigned, ad-hoc signed, or the team
+    /// identifier cannot be read.
+    ///
+    /// Both sides of the XPC connection (Ice ↔ MenuBarItemService.xpc) use
+    /// this to decide whether to enforce `.isFromSameTeam()` on their
+    /// peer requirements. The `.isFromSameTeam()` predicate silently
+    /// rejects every peer when there's no team identifier to compare —
+    /// the case for any ad-hoc-signed build, including every community
+    /// fork shipped without an Apple Developer Program account. Without
+    /// the guard, Ice rejects its own helper service, the helper
+    /// rejects Ice back, and the Menu Bar Layout settings pane spins
+    /// forever on "Loading menu bar items…". This is the same class as
+    /// upstream issues #744 and #891.
+    static func ownTeamIdentifier() -> String? {
+        var staticCode: SecStaticCode?
+        guard
+            SecStaticCodeCreateWithPath(Bundle.main.bundleURL as CFURL, [], &staticCode) == errSecSuccess,
+            let code = staticCode
+        else {
+            return nil
+        }
+        var info: CFDictionary?
+        guard
+            SecCodeCopySigningInformation(code, SecCSFlags(rawValue: 0), &info) == errSecSuccess,
+            let dict = info as? [String: Any],
+            let teamID = dict[kSecCodeInfoTeamIdentifier as String] as? String,
+            !teamID.isEmpty
+        else {
+            return nil
+        }
+        return teamID
+    }
 }
 
 extension MenuBarItemService {


### PR DESCRIPTION
## What

Restores `MenuBarItemService` XPC connectivity for community ad-hoc-signed builds of Ice on macOS 26 Tahoe.

## Why

On macOS 26, the new `XPCSession.setPeerRequirement(.isFromSameTeam())` API **silently rejects every peer** when the calling process has no Team Identifier — which is the case for any ad-hoc-signed build (every community fork, every `xcodebuild` from source). The current `Listener.swift` and `MenuBarItemServiceConnection.swift` unconditionally apply this requirement, so:

- The XPC listener is created but rejects the parent app's connection
- The client `Connection.sourcePID(...)` always returns `nil`
- `MenuBarItemManager.uncheckedCacheItems` logs `Missing sourcePID for ...` every few seconds
- The Menu Bar Layout settings pane has no PIDs to render — shows empty rows / blank list

This is the upstream class causing:

- [#744 — Menu Bar Layout settings is empty](https://github.com/jordanbaird/Ice/issues/744) (46 reactions)
- [#891 — ICons List Blank In Settings](https://github.com/jordanbaird/Ice/issues/891) (30 reactions)
- [#913 — Settings Menu: Menu Bar Layout Icons Do Not Appear](https://github.com/jordanbaird/Ice/issues/913) (5 reactions)
- [#846 — MenuBar in Settings Is Empty White Space](https://github.com/jordanbaird/Ice/issues/846) (27 reactions)
- [#818 — Menu bar layout editor is just empty/white](https://github.com/jordanbaird/Ice/issues/818) (7 reactions)
- [#832 — Menu Bar Layout with Tahoe OS](https://github.com/jordanbaird/Ice/issues/832) (5 reactions)
- [#872 — Unstable, Layout menu area broken](https://github.com/jordanbaird/Ice/issues/872) (8 reactions, partially)

Combined: **~130 reactions across the bug class.**

## How

Introduces a shared `MenuBarItemService.ownTeamIdentifier()` helper in `Shared/Services/MenuBarItemService.swift` that returns the running process's Team Identifier via `SecStaticCode`, or `nil` if the binary is ad-hoc-signed.

Both sides of the XPC handshake gate their `.isFromSameTeam()` enforcement on `ownTeamIdentifier() != nil`:

- `MenuBarItemService/Listener.swift` — listener falls back to unrestricted activation when no Team ID is available
- `Ice/MenuBar/MenuBarItems/MenuBarItemServiceConnection.swift` — client skips `setPeerRequirement(.isFromSameTeam())` when no Team ID is available

**Developer-ID-signed builds (App Store / future TestFlight / signed releases) keep strict same-team enforcement automatically** — the helper returns the real Team ID and the requirement applies on both sides. Only community ad-hoc builds skip the requirement, which is the only configuration that can't satisfy it anyway.

## Testing

Verified on:

- macOS 26.5 Tahoe, MacBook Pro Apple Silicon
- Ad-hoc-signed build (`xcodebuild` from source): Menu Bar Layout pane populates correctly, all three sections (Visible / Hidden / Always-Hidden) render menu bar items
- Developer-ID-signed + Apple-notarized build: same behavior, strict same-team requirement still enforced (verified via `codesign -dv` showing both peers signed by same Team ID)

A working signed + notarized DMG that ships these commits is available for reviewers who want to test without rebuilding: <https://github.com/pdurlej/Ice/releases/latest> (same `com.jordanbaird.Ice` bundle ID, drop-in replacement).

## Notes

This PR is offered in good faith to the upstream repo — the same fix has been deployed in a community fork ([pdurlej/Ice](https://github.com/pdurlej/Ice), "Fire from Ice") since 2026-05-24 and confirmed working by multiple users on macOS 26.4–26.5. Happy to iterate on the patch shape if a different approach is preferred.

Closes (or contributes toward closing): #744, #891, #913, #846, #818, #832, #872.
