### PR TITLE
Allow MenuBarItemService XPC connection on builds without a Team Identifier

### DIFF
--- a/Ice/MenuBar/MenuBarItems/MenuBarItemServiceConnection.swift
+++ b/Ice/MenuBar/MenuBarItems/MenuBarItemServiceConnection.swift
@@ -104,7 +104,14 @@ extension MenuBarItemService {
                     logger.warning("Session was cancelled with error \(error.localizedDescription)")
                     self.session = nil
                 }
-                session.setPeerRequirement(.isFromSameTeam())
+                // The `isFromSameTeam` requirement can only be satisfied when the
+                // process has a Team Identifier. Ad-hoc/local development builds
+                // have none, so skip the peer requirement for them.
+                if CodeSigning.hasTeamIdentifier {
+                    session.setPeerRequirement(.isFromSameTeam())
+                } else {
+                    logger.notice("Connecting without same-team peer requirement (no Team Identifier)")
+                }
                 session.setTargetQueue(queue)
                 try session.activate()
                 self.session = session

--- a/MenuBarItemService/Listener.swift
+++ b/MenuBarItemService/Listener.swift
@@ -73,9 +73,15 @@ final class Listener {
         Logger.default.debug("Activating listener")
 
         do {
-            if #available(macOS 26.0, *) {
+            // The `isFromSameTeam` requirement can only be satisfied when the
+            // process has a Team Identifier. Ad-hoc/local development builds
+            // have none, so fall back to an unrestricted listener for them.
+            if #available(macOS 26.0, *), CodeSigning.hasTeamIdentifier {
                 try uncheckedActivateWithSameTeamRequirement()
             } else {
+                if #available(macOS 26.0, *) {
+                    Logger.default.notice("Activating listener without same-team requirement (no Team Identifier)")
+                }
                 try uncheckedActivate()
             }
         } catch {

--- a/Shared/Utilities/CodeSigning.swift
+++ b/Shared/Utilities/CodeSigning.swift
@@ -1,0 +1,52 @@
+//
+//  CodeSigning.swift
+//  Shared
+//
+
+import Security
+
+/// Utilities for inspecting the current process's code signature.
+enum CodeSigning {
+    /// The Team Identifier of the running process, or `nil` if the process
+    /// is unsigned or ad-hoc signed (i.e. has no Team Identifier).
+    ///
+    /// Ad-hoc/local development builds have no Team Identifier, which is why
+    /// this is used to decide whether the `isFromSameTeam` XPC peer
+    /// requirement can be satisfied.
+    static var teamIdentifier: String? {
+        var code: SecCode?
+        guard
+            SecCodeCopySelf([], &code) == errSecSuccess,
+            let code
+        else {
+            return nil
+        }
+
+        var staticCode: SecStaticCode?
+        guard
+            SecCodeCopyStaticCode(code, [], &staticCode) == errSecSuccess,
+            let staticCode
+        else {
+            return nil
+        }
+
+        var info: CFDictionary?
+        guard
+            SecCodeCopySigningInformation(staticCode, SecCSFlags(rawValue: kSecCSSigningInformation), &info) == errSecSuccess,
+            let dict = info as? [String: Any],
+            let team = dict[kSecCodeInfoTeamIdentifier as String] as? String,
+            !team.isEmpty
+        else {
+            return nil
+        }
+
+        return team
+    }
+
+    /// A Boolean value indicating whether the current process has a Team
+    /// Identifier, meaning the `isFromSameTeam` XPC peer requirement can be
+    /// enforced. Ad-hoc/local builds return `false`.
+    static var hasTeamIdentifier: Bool {
+        teamIdentifier != nil
+    }
+}


### PR DESCRIPTION
## Summary

On the `macos-26` branch, the new `MenuBarItemService` enforces an `isFromSameTeam` requirement on **both** sides of the XPC link:

- Listener: `XPCListener(service: name, requirement: .isFromSameTeam())` (`MenuBarItemService/Listener.swift`)
- Client: `session.setPeerRequirement(.isFromSameTeam())` (`Ice/MenuBar/MenuBarItems/MenuBarItemServiceConnection.swift`)

Ad-hoc / locally-signed builds have **no Team Identifier**, so this requirement can never be satisfied. The XPC session is rejected at activation:

```
[MenuBarItemService.Connection] Session failed with error Error Domain=XPC.XPCRichError Code=1
[MenuBarItemService.Connection] Start request returned nil
[MenuBarItemService.Connection] Source PID request returned nil
```

Because source PIDs are never resolved on macOS 26 (item windows are owned by Control Center, so the source app is found via the XPC service), the menu bar item list stays empty and the UI is stuck on "Loading menu bar items…" indefinitely. This makes the branch unusable for anyone building locally without a Developer Team.

## Changes

- Add `Shared/Utilities/CodeSigning.swift`, exposing `CodeSigning.teamIdentifier` / `hasTeamIdentifier` via `SecCodeCopySigningInformation`.
- Gate the `isFromSameTeam` requirement on whether the running process actually has a Team Identifier:
  - **Signed builds (with a team):** unchanged — the same-team requirement is still enforced.
  - **Ad-hoc / local builds (no team):** fall back to an unrestricted listener / no peer requirement so the connection succeeds.

No-op for release builds; only relaxes the requirement when there is no team to enforce it against.

## Related

This is the same class of issue as #744 / #891, and overlaps with #950 and one commit of #903 (all three independently added a team-identifier guard). Happy to consolidate toward whichever approach you prefer.

## Test plan

- [x] Builds on Xcode 26 / Swift 6.3 / macOS 26.5.
- [x] Ad-hoc signed build: XPC session connects, source PIDs resolve, item list populates.
- [x] Developer ID signed build (app + service same team): same-team requirement is still used and satisfied.